### PR TITLE
Fix ember-views.render-double-modify error

### DIFF
--- a/addon/components/route-shy.js
+++ b/addon/components/route-shy.js
@@ -5,7 +5,8 @@ import computed from 'ember-new-computed';
 const {
   Component,
   getWithDefault,
-  set
+  set,
+  run
 } = Ember;
 
 const {
@@ -79,7 +80,9 @@ export default Component.extend({
     }
 
     if (this.get('syncWith') && this.get('syncProperty')) {
-      set(this.get('syncWith'), `${this.get('syncProperty') || ''}`, isVisible);
+      run.scheduleOnce('afterRender', this, () => {
+        set(this.get('syncWith'), `${this.get('syncProperty') || ''}`, isVisible);
+      });
     }
     return isVisible;
   }),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-route-shy-component",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A component that won't render when the application's current route matches a preconfigured condition",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Wrap the setting operation for syncing  in a `Ember.run.scheduleOnce('afterRender...` to avoid `ember-views.render-double-modify` errors.
